### PR TITLE
Textures.Go

### DIFF
--- a/circles.go
+++ b/circles.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"image"
+	"image/png"
+	"log"
+	"os"
+)
+
+type Palette [][]byte
+
+func LoadTextRGBPalette(filename string) (Palette, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	var palette Palette
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		var red, green, blue int
+		items, err := fmt.Sscanf(line, "%d %d %d", &red, &green, &blue)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if items != 3 {
+			log.Println("not expected line:", line)
+		}
+		color := []byte{byte(red), byte(green), byte(blue)}
+		palette = append(palette, color)
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+	return palette, err
+}
+
+// PNGImageWriter implements image.Writer interface, it writes PNG format
+type PNGImageWriter struct{}
+
+// WritePNGImage writes an image represented by standard image.Image structure into file with PNG format.
+func (writer PNGImageWriter) WriteImage(filename string, img image.Image) error {
+	outfile, err := os.Create(filename)
+	if err != nil {
+		panic(err)
+	}
+	defer outfile.Close()
+	return png.Encode(outfile, img)
+}
+
+// NewPNGImageWriter is a constructor for PNG image writer
+func NewPNGImageWriter() PNGImageWriter {
+	return PNGImageWriter{}
+}
+
+// ZPixel is a representation of pixel in complex plane with additional metadata
+type ZPixel struct {
+	Iter uint
+	Z    complex128
+}
+
+// ZImage is representation of raster image consisting of ZPixels
+type ZImage [][]ZPixel
+
+// NewZImage constructs new instance of ZImage
+func NewZImage(width uint, height uint) ZImage {
+	zimage := make([][]ZPixel, height)
+	for i := uint(0); i < height; i++ {
+		zimage[i] = make([]ZPixel, width)
+	}
+	return zimage
+}
+
+func complexImageToImage(zimage ZImage, width uint, height uint, palette Palette) image.Image {
+	image := image.NewNRGBA(image.Rect(0, 0, int(width), int(height)))
+
+	for y := 0; y < int(height); y++ {
+		offset := image.PixOffset(0, y)
+		for x := uint(0); x < width; x++ {
+			i := byte(zimage[y][x].Iter)
+			image.Pix[offset] = palette[i][0]
+			offset++
+			image.Pix[offset] = palette[i][1]
+			offset++
+			image.Pix[offset] = palette[i][2]
+			offset++
+			image.Pix[offset] = 0xff
+			offset++
+		}
+	}
+	return image
+}
+
+func renderCirclePattern(zimage ZImage, width uint, height uint, xmin, ymin, xmax, ymax float32) {
+	stepx := (xmax - xmin) / float32(width)
+	stepy := (ymax - ymin) / float32(height)
+
+	y1 := ymin
+	for y := range height {
+		x1 := xmin
+		for x := range width {
+			x2 := x1 * x1
+			y2 := y1 * y1
+			i := (int)(x2+y2) & 255
+			zimage[y][x] = ZPixel{Iter: uint(i)}
+			x1 += stepx
+		}
+		y1 += stepy
+	}
+}
+
+type patternHandler func(x, y float32) float32
+
+func renderCircleLikePattern(
+	zimage ZImage, width uint, height uint,
+	xmin, ymin, xmax, ymax float32,
+	function patternHandler) {
+	stepx := (xmax - xmin) / float32(width)
+	stepy := (ymax - ymin) / float32(height)
+
+	y1 := ymin
+	for y := range height {
+		x1 := xmin
+		for x := range width {
+			value := function(x1, y1)
+			i := int(value)
+			zimage[y][x] = ZPixel{Iter: uint(i)}
+			x1 += stepx
+		}
+		y1 += stepy
+	}
+}
+
+func main() {
+	palette, err := LoadTextRGBPalette("mandmap.map")
+	if err != nil {
+		panic(err)
+	}
+	zimage := NewZImage(512, 512)
+	renderCirclePattern(zimage, 512, 512, -200.0, -200.0, 200.0, 200.0)
+	image := complexImageToImage(zimage, 512, 512, palette)
+	imageWriter := NewPNGImageWriter()
+	imageWriter.WriteImage("circles.png", image)
+
+	renderCircleLikePattern(zimage, 512, 512, -200.0, -200.0, 200.0, 200.0,
+		func(x, y float32) float32 { return x*x - y*y })
+	image = complexImageToImage(zimage, 512, 512, palette)
+	imageWriter.WriteImage("circles1.png", image)
+
+	renderCircleLikePattern(zimage, 512, 512, -50.0, -50.0, 0.0, 0.0,
+		func(x, y float32) float32 { return x*x*x + y*y*y })
+	image = complexImageToImage(zimage, 512, 512, palette)
+	imageWriter.WriteImage("circles2.png", image)
+
+	renderCircleLikePattern(zimage, 512, 512, -50.0, -50.0, 0.0, 0.0,
+		func(x, y float32) float32 { return x*x*y + y*y*x })
+	image = complexImageToImage(zimage, 512, 512, palette)
+	imageWriter.WriteImage("circles3.png", image)
+
+	renderCircleLikePattern(zimage, 512, 512, -250.0, -250.0, 250.0, 250.0,
+		func(x, y float32) float32 { return x*x + y*y + x*y })
+	image = complexImageToImage(zimage, 512, 512, palette)
+	imageWriter.WriteImage("circles4.png", image)
+}

--- a/fm_synth.go
+++ b/fm_synth.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"image"
+	"image/png"
+	"log"
+	"math"
+	"os"
+)
+
+type Palette [][]byte
+
+func LoadTextRGBPalette(filename string) (Palette, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	var palette Palette
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		var red, green, blue int
+		items, err := fmt.Sscanf(line, "%d %d %d", &red, &green, &blue)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if items != 3 {
+			log.Println("not expected line:", line)
+		}
+		color := []byte{byte(red), byte(green), byte(blue)}
+		palette = append(palette, color)
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+	return palette, err
+}
+
+// PNGImageWriter implements image.Writer interface, it writes PNG format
+type PNGImageWriter struct{}
+
+// WritePNGImage writes an image represented by standard image.Image structure into file with PNG format.
+func (writer PNGImageWriter) WriteImage(filename string, img image.Image) error {
+	outfile, err := os.Create(filename)
+	if err != nil {
+		panic(err)
+	}
+	defer outfile.Close()
+	return png.Encode(outfile, img)
+}
+
+// NewPNGImageWriter is a constructor for PNG image writer
+func NewPNGImageWriter() PNGImageWriter {
+	return PNGImageWriter{}
+}
+
+// ZPixel is a representation of pixel in complex plane with additional metadata
+type ZPixel struct {
+	Iter uint
+	Z    complex128
+}
+
+// ZImage is representation of raster image consisting of ZPixels
+type ZImage [][]ZPixel
+
+// NewZImage constructs new instance of ZImage
+func NewZImage(width uint, height uint) ZImage {
+	zimage := make([][]ZPixel, height)
+	for i := uint(0); i < height; i++ {
+		zimage[i] = make([]ZPixel, width)
+	}
+	return zimage
+}
+
+func complexImageToImage(zimage ZImage, width uint, height uint, palette Palette) image.Image {
+	image := image.NewNRGBA(image.Rect(0, 0, int(width), int(height)))
+
+	for y := 0; y < int(height); y++ {
+		offset := image.PixOffset(0, y)
+		for x := uint(0); x < width; x++ {
+			i := byte(zimage[y][x].Iter)
+			image.Pix[offset] = palette[i][0]
+			offset++
+			image.Pix[offset] = palette[i][1]
+			offset++
+			image.Pix[offset] = palette[i][2]
+			offset++
+			image.Pix[offset] = 0xff
+			offset++
+		}
+	}
+	return image
+}
+
+func renderFMPattern(zimage ZImage, width uint, height uint, xmin, ymin, xmax, ymax float32) {
+	stepx := (xmax - xmin) / float32(width)
+	stepy := (ymax - ymin) / float32(height)
+
+	y1 := ymin
+	for y := range height {
+		x1 := xmin
+		for x := range width {
+			val := 100.0 + 100.0*math.Sin(float64(x1)/4.0+2*math.Sin(float64(x1)/15.0+float64(y1)/40.0))
+			i := int(val) & 255
+			zimage[y][x] = ZPixel{Iter: uint(i)}
+			x1 += stepx
+		}
+		y1 += stepy
+	}
+}
+
+func main() {
+	palette, err := LoadTextRGBPalette("mandmap.map")
+	if err != nil {
+		panic(err)
+	}
+	zimage := NewZImage(512, 512)
+	renderFMPattern(zimage, 512, 512, -100.0, -100.0, 100.0, 100.0)
+	image := complexImageToImage(zimage, 512, 512, palette)
+	imageWriter := NewPNGImageWriter()
+	imageWriter.WriteImage("fm1.png", image)
+}

--- a/plasma.go
+++ b/plasma.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"image"
+	"image/png"
+	"log"
+	"math"
+	"math/rand/v2"
+	"os"
+)
+
+type Palette [][]byte
+
+func LoadTextRGBPalette(filename string) (Palette, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	var palette Palette
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		var red, green, blue int
+		items, err := fmt.Sscanf(line, "%d %d %d", &red, &green, &blue)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if items != 3 {
+			log.Println("not expected line:", line)
+		}
+		color := []byte{byte(red), byte(green), byte(blue)}
+		palette = append(palette, color)
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+	return palette, err
+}
+
+// PNGImageWriter implements image.Writer interface, it writes PNG format
+type PNGImageWriter struct{}
+
+// WritePNGImage writes an image represented by standard image.Image structure into file with PNG format.
+func (writer PNGImageWriter) WriteImage(filename string, img image.Image) error {
+	outfile, err := os.Create(filename)
+	if err != nil {
+		panic(err)
+	}
+	defer outfile.Close()
+	return png.Encode(outfile, img)
+}
+
+// NewPNGImageWriter is a constructor for PNG image writer
+func NewPNGImageWriter() PNGImageWriter {
+	return PNGImageWriter{}
+}
+
+// ZPixel is a representation of pixel in complex plane with additional metadata
+type ZPixel struct {
+	Iter uint
+	Z    complex128
+}
+
+// ZImage is representation of raster image consisting of ZPixels
+type ZImage [][]ZPixel
+
+// NewZImage constructs new instance of ZImage
+func NewZImage(width uint, height uint) ZImage {
+	zimage := make([][]ZPixel, height)
+	for i := uint(0); i < height; i++ {
+		zimage[i] = make([]ZPixel, width)
+	}
+	return zimage
+}
+
+func complexImageToImage(zimage ZImage, width uint, height uint, palette Palette) image.Image {
+	image := image.NewNRGBA(image.Rect(0, 0, int(width), int(height)))
+
+	for y := 0; y < int(height); y++ {
+		offset := image.PixOffset(0, y)
+		for x := uint(0); x < width; x++ {
+			i := byte(zimage[y][x].Iter)
+			image.Pix[offset] = palette[i][0]
+			offset++
+			image.Pix[offset] = palette[i][1]
+			offset++
+			image.Pix[offset] = palette[i][2]
+			offset++
+			image.Pix[offset] = 0xff
+			offset++
+		}
+	}
+	return image
+}
+
+func randomGauss() float32 {
+	const N = 50
+	sum := float32(0)
+	for range N {
+		sum += rand.Float32()
+	}
+	return sum / N
+}
+
+type FImage [][]float32
+
+// NewFImage constructs new instance of FImage
+func NewFImage(width uint, height uint) FImage {
+	fimage := make([][]float32, height)
+	for i := uint(0); i < height; i++ {
+		fimage[i] = make([]float32, width)
+	}
+	return fimage
+}
+func minMax(img FImage, width, height uint) (float32, float32) {
+	min := float32(math.Inf(1))
+	max := float32(math.Inf(-1))
+
+	for j := range height {
+		for i := range width {
+			z := img[j][i]
+			if max < z {
+				max = z
+			}
+			if min > z {
+				min = z
+			}
+		}
+	}
+	return min, max
+}
+
+func floatImageToImage(fimage FImage, width uint, height uint, palette Palette) image.Image {
+	image := image.NewNRGBA(image.Rect(0, 0, int(width), int(height)))
+	min, max := minMax(fimage, width, height)
+	k := 255.0 / (max - min)
+
+	for y := uint(0); y < height; y++ {
+		offset := image.PixOffset(0, int(y))
+		for x := uint(0); x < width; x++ {
+			f := fimage[y][x]
+			f -= min
+			f *= k
+			i := int(f) & 255
+			image.Pix[offset] = palette[i][0]
+			offset++
+			image.Pix[offset] = palette[i][1]
+			offset++
+			image.Pix[offset] = palette[i][2]
+			offset++
+			image.Pix[offset] = 0xff
+			offset++
+		}
+	}
+	return image
+}
+
+func spectralSynthesis(img FImage, width, height uint, n uint, h float32) {
+	A := NewFImage(n/2, n/2)
+	B := NewFImage(n/2, n/2)
+	beta := float64(2.0*h + 1)
+
+	for j := range n / 2 {
+		for i := range n / 2 {
+			rad_i := math.Pow(float64(i)+1.0, -beta/2.0) * float64(randomGauss())
+			rad_j := math.Pow(float64(j)+1.0, -beta/2.0) * float64(randomGauss())
+			phase_i := 2.0 * math.Pi * rand.Float64()
+			phase_j := 2.0 * math.Pi * rand.Float64()
+			A[j][i] = float32(rad_i * math.Cos(phase_i) * rad_j * math.Cos(phase_j))
+			B[j][i] = float32(rad_i * math.Sin(phase_i) * rad_j * math.Sin(phase_j))
+		}
+	}
+
+	for j := range height {
+		for i := range width {
+			z := 0.0
+			for k := range n / 2 {
+				for l := range n / 2 {
+					u := float64(i) * 2.0 * math.Pi / float64(width)
+					v := float64(j) * 2.0 * math.Pi / float64(height)
+					w := float64(k)*u + float64(l)*v
+					z += float64(A[k][l])*math.Cos(w) +
+						float64(B[k][l])*math.Sin(w)
+				}
+			}
+			img[j][i] = float32(z)
+		}
+	}
+}
+
+func main() {
+	palette, err := LoadTextRGBPalette("mandmap.map")
+	if err != nil {
+		panic(err)
+	}
+	fimage := NewFImage(512, 512)
+	spectralSynthesis(fimage, 512, 512, 4, 0.5)
+	image := floatImageToImage(fimage, 512, 512, palette)
+	imageWriter := NewPNGImageWriter()
+	imageWriter.WriteImage("plasma.png", image)
+}

--- a/voronoi.go
+++ b/voronoi.go
@@ -1,0 +1,112 @@
+// MIT License
+//
+// Copyright (c) 2020 Pavel Tišnovský
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package main
+
+import (
+	"math"
+
+	"github.com/veandco/go-sdl2/sdl"
+)
+
+const (
+	width  = 640
+	height = 480
+)
+
+func putpixel(surface *sdl.Surface, x int32, y int32, r byte, g byte, b byte) {
+	if x >= 0 && x < surface.W && y >= 0 && y < surface.H {
+		switch surface.Format.BitsPerPixel {
+		case 24:
+			index := x*3 + y*surface.Pitch
+			pixels := surface.Pixels()
+			pixels[index] = b
+			pixels[index+1] = g
+			pixels[index+2] = r
+		case 32:
+			index := x*4 + y*surface.Pitch
+			pixels := surface.Pixels()
+			pixels[index] = b
+			pixels[index+1] = g
+			pixels[index+2] = r
+		}
+	}
+}
+
+type Point struct {
+	X float64
+	Y float64
+}
+
+func main() {
+	if err := sdl.Init(sdl.INIT_VIDEO); err != nil {
+		panic(err)
+	}
+	defer sdl.Quit()
+
+	window, err := sdl.CreateWindow("Texture based on Voronoi diagram", sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED,
+		width, height, sdl.WINDOW_SHOWN)
+	if err != nil {
+		panic(err)
+	}
+	defer window.Destroy()
+
+	primarySurface, err := window.GetSurface()
+	if err != nil {
+		panic(err)
+	}
+
+	points := []Point{
+		{100, 200},
+		{200, 100},
+		{500, 100},
+		{400, 420},
+		{150, 50},
+		{250, 400},
+		{550, 520},
+		{400, 100},
+	}
+	for y := int32(0); y < height; y++ {
+		for x := int32(0); x < width; x++ {
+			var color byte = 0
+			var minDistance float64 = math.MaxFloat64
+			for i := 0; i < len(points); i++ {
+				distance := math.Hypot(float64(x)-points[i].X, float64(y)-points[i].Y)
+				if distance < minDistance {
+					d := distance
+					if d > 255 {
+						d = 255
+					}
+					color = byte(d)
+					minDistance = distance
+				}
+			}
+			putpixel(primarySurface, x, y, color, color, color)
+		}
+	}
+
+	sdl.Delay(100)
+
+	window.UpdateSurface()
+
+	sdl.Delay(2000)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added palette-driven image generators for circle and FM-style patterns; export 512×512 PNGs.
  - Introduced a plasma fractal generator using spectral synthesis; saves as PNG.
  - Added a Voronoi diagram viewer that renders a grayscale nearest-site map in a window.
  - Shared palette loading and PNG writing utilities for consistent color mapping and output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->